### PR TITLE
BUG-11 Fixed null date causing blank Milestone report

### DIFF
--- a/Topo/Models/Milestone/GetGroupLifeResultModel.cs
+++ b/Topo/Models/Milestone/GetGroupLifeResultModel.cs
@@ -49,7 +49,7 @@
         public int milestone { get; set; }
         public bool awarded { get; set; }
         public Participate[] participates { get; set; } = new Participate[0];
-        public DateTime status_updated { get; set; }
+        public DateTime? status_updated { get; set; }
         public int total_assists { get; set; }
         public int total_leads { get; set; }
     }


### PR DESCRIPTION
Fixed deserialization issue caused by null date in Milestone result JSON by making status_updated a nullable type