### PR TITLE
Issue-86: OAS Reports: Use single digit month in date conversion

### DIFF
--- a/.github/workflows/develop.dotnet.yml
+++ b/.github/workflows/develop.dotnet.yml
@@ -17,7 +17,7 @@ jobs:
         dotnet-version: 6.0.x
     - name: version
       id: generate_version
-      run: echo "::set-output name=version::1.22.$(($GITHUB_RUN_NUMBER))"
+      run: echo "::set-output name=version::1.23.$(($GITHUB_RUN_NUMBER))"
     - name: Restore dependencies
       run: dotnet restore
     - name: Build

--- a/Topo/Constants.cs
+++ b/Topo/Constants.cs
@@ -2,6 +2,6 @@
 {
     public static class Constants
     {
-        public const string Version = "1.22";
+        public const string Version = "1.23";
     }
 }

--- a/Topo/Services/OASService.cs
+++ b/Topo/Services/OASService.cs
@@ -251,7 +251,7 @@ namespace Topo.Services
                                 {
                                     try
                                     {
-                                        worksheetAnswer.MemberAnswer = ConvertAnswerDate(answer.Value);
+                                        worksheetAnswer.MemberAnswer = ConvertAnswerDate(answer.Value, memberAchievement.status_updated);
                                     }
                                     catch (Exception ex)
                                     {
@@ -319,7 +319,7 @@ namespace Topo.Services
                             if (worksheetAnswer != null)
                                 try
                                 {
-                                    worksheetAnswer.MemberAnswer = ConvertAnswerDate(answer.Value);
+                                    worksheetAnswer.MemberAnswer = ConvertAnswerDate(answer.Value, memberAchievement.status_updated);
                                 }
                                 catch (Exception ex)
                                 {
@@ -345,7 +345,7 @@ namespace Topo.Services
 
             return sortedAnswers;
         }
-        private DateTime ConvertAnswerDate(string answerValue)
+        private DateTime ConvertAnswerDate(string answerValue, DateTime updatedDate)
         {
             // Question answer dates seem to be either AU or US format. WTF!
             // "south_magnetic_find_electronic_means_compass_west_directions_e7e4fc_verifiedDate": "18/11/2020",
@@ -354,11 +354,14 @@ namespace Topo.Services
             try
             {
                 answerDate = DateTime.ParseExact(answerValue, "dd/MM/yyyy", CultureInfo.InvariantCulture); // Date in AU format
+                if (answerDate > updatedDate) 
+                    // Answer date is after when the record was updated, so treat as a US date.
+                    answerDate = DateTime.ParseExact(answerValue, "M/dd/yyyy", CultureInfo.InvariantCulture); // Date in US format
                 return answerDate;
             }
             catch
             {
-                answerDate = DateTime.ParseExact(answerValue, "MM/dd/yyyy", CultureInfo.InvariantCulture); // Date in UA format
+                answerDate = DateTime.ParseExact(answerValue, "M/dd/yyyy", CultureInfo.InvariantCulture); // Date in US format
                 return answerDate;
             }
         }


### PR DESCRIPTION
Some achievement dates are being stored in US date format.
Convert to date time object.