### PR TITLE
ISSUE-137 Added option to OAS to format report like Terrain

### DIFF
--- a/Models/OAS/OASIndexViewModel.cs
+++ b/Models/OAS/OASIndexViewModel.cs
@@ -19,5 +19,8 @@ namespace Topo.Models.OAS
         [Display(Name = "Break by Patrol")]
         public bool BreakByPatrol { get; set; }
 
+        [Display(Name = "Format Like Terrain")]
+        public bool FormatLikeTerrain { get; set; }
+
     }
 }

--- a/Services/ReportService.cs
+++ b/Services/ReportService.cs
@@ -1032,9 +1032,9 @@ namespace Topo.Services
                     sheet.Range[rowNumber, columnNumber].Text = plan.InputTitle;
                     sheet.Range[rowNumber, columnNumber].CellStyle.Color = GetInputTitleColour(plan.InputTitle);
                     sheet.Range[rowNumber, columnNumber].BorderAround();
-                    sheet.Range[rowNumber, columnNumber].CellStyle.Rotation = 90;
+                    sheet.Range[rowNumber, columnNumber].CellStyle.Rotation = 0;
                     sheet.Range[rowNumber, columnNumber].CellStyle.Font.Bold = true;
-                    sheet.Range[rowNumber, columnNumber].CellStyle.HorizontalAlignment = ExcelHAlign.HAlignCenter;
+                    sheet.Range[rowNumber, columnNumber].CellStyle.VerticalAlignment = ExcelVAlign.VAlignCenter;
                     if (pdrStartRow > rowNumber)
                         pdrStartRow = rowNumber;
                     else
@@ -1066,6 +1066,8 @@ namespace Topo.Services
                 sheet.Range[rowNumber, columnNumber].Text = groupedAnswer.Key;
                 sheet.Range[rowNumber, columnNumber].BorderAround();
                 sheet.Range[rowNumber, columnNumber].CellStyle.Font.Bold = true;
+                sheet.Range[rowNumber, columnNumber].CellStyle.Rotation = 90;
+                sheet.Range[rowNumber, columnNumber].CellStyle.HorizontalAlignment = ExcelHAlign.HAlignCenter;
 
                 foreach (var answer in groupedAnswer.OrderBy(ga => ga.InputTitleSortIndex).ThenBy(ga => ga.InputSortIndex))
                 {

--- a/Services/ReportService.cs
+++ b/Services/ReportService.cs
@@ -21,7 +21,7 @@ namespace Topo.Services
         public IWorkbook GenerateSignInSheetWorkbook(List<MemberListModel> memberListModel, string groupName, string section, string unitName, string eventName);
         public IWorkbook GenerateEventAttendanceWorkbook(EventListModel eventListModel, string groupName, string section, string unitName);
         public IWorkbook GenerateAttendanceReportWorkbook(AttendanceReportModel attendanceReportData, string groupName, string section, string unitName, DateTime fromDate, DateTime toDate, bool forPdfOutput);
-        public IWorkbook GenerateOASWorksheetWorkbook(List<OASWorksheetAnswers> worksheetAnswers, string groupName, string section, string unitName, bool forPdfOutput, bool showByPatrol = false);
+        public IWorkbook GenerateOASWorksheetWorkbook(List<OASWorksheetAnswers> worksheetAnswers, string groupName, string section, string unitName, bool forPdfOutput, bool formatLikeTerrain, bool showByPatrol = false);
         public IWorkbook GenerateSIAWorkbook(List<SIAProjectListModel> siaProjects, string groupName, string section, string unitName, bool forPdfOutput);
         public IWorkbook GenerateMilestoneWorkbook(List<MilestoneSummaryListModel> milestoneSummaries, string groupName, string section, string unitName, bool forPdfOutput);
         public IWorkbook GenerateLogbookWorkbook(List<MemberLogbookReportViewModel> logbookEntries, string groupName, string section, string unitName, bool forPdfOutput);
@@ -1017,7 +1017,139 @@ namespace Topo.Services
             return workbook;
         }
 
-        public IWorkbook GenerateOASWorksheetWorkbook(List<OASWorksheetAnswers> worksheetAnswers, string groupName, string section, string unitName, bool forPdfOutput, bool breakByPatrol = false)
+        private void GenerateOASWorksheetBodyLikeTerrain(IWorksheet sheet, IList<IGrouping<string, OASWorksheetAnswers>> groupedAnswers, ref int rowNumber, ref int columnNumber)
+        {
+            var pdrText = "";
+            var titleRow = rowNumber;
+            int pdrStartRow = 99;
+            foreach (var plan in groupedAnswers.FirstOrDefault().OrderBy(ga => ga.InputTitleSortIndex).ThenBy(ga => ga.InputSortIndex).ToList())
+            {
+                // Plan Do Review
+                rowNumber++;
+                if (pdrText != plan.InputTitle)
+                {
+                    pdrText = plan.InputTitle;
+                    sheet.Range[rowNumber, columnNumber].Text = plan.InputTitle;
+                    sheet.Range[rowNumber, columnNumber].CellStyle.Color = GetInputTitleColour(plan.InputTitle);
+                    sheet.Range[rowNumber, columnNumber].BorderAround();
+                    sheet.Range[rowNumber, columnNumber].CellStyle.Rotation = 90;
+                    sheet.Range[rowNumber, columnNumber].CellStyle.Font.Bold = true;
+                    sheet.Range[rowNumber, columnNumber].CellStyle.HorizontalAlignment = ExcelHAlign.HAlignCenter;
+                    if (pdrStartRow > rowNumber)
+                        pdrStartRow = rowNumber;
+                    else
+                    {
+                        sheet.Range[pdrStartRow, columnNumber, rowNumber - 1, columnNumber].Merge();
+                        sheet.Range[pdrStartRow, columnNumber, rowNumber - 1, columnNumber].BorderAround();
+                        pdrStartRow = rowNumber;
+                    }
+                }
+
+                // iStatement
+                sheet.Range[rowNumber, columnNumber + 1].Text = plan.InputLabel;
+                sheet.Range[rowNumber, columnNumber + 1].BorderAround();
+                sheet.Range[rowNumber, columnNumber + 1].CellStyle.Font.Bold = true;
+                sheet.Range[rowNumber, columnNumber + 1].CellStyle.HorizontalAlignment = ExcelHAlign.HAlignCenter;
+                sheet.Range[rowNumber, columnNumber + 1].CellStyle.Rotation = 0;
+                sheet.Range[rowNumber, columnNumber + 1].CellStyle.WrapText = true;
+                sheet.SetColumnWidth(columnNumber + 1, 50);
+                sheet.AutofitRow(rowNumber);
+            }
+
+            // Member Name and answers
+            columnNumber++;
+            sheet.Range[titleRow + 1, columnNumber + 1].FreezePanes();
+            rowNumber = titleRow;
+            foreach (var groupedAnswer in groupedAnswers.OrderBy(ga => ga.Key))
+            {
+                columnNumber++;
+                sheet.Range[rowNumber, columnNumber].Text = groupedAnswer.Key;
+                sheet.Range[rowNumber, columnNumber].BorderAround();
+                sheet.Range[rowNumber, columnNumber].CellStyle.Font.Bold = true;
+
+                foreach (var answer in groupedAnswer.OrderBy(ga => ga.InputTitleSortIndex).ThenBy(ga => ga.InputSortIndex))
+                {
+                    rowNumber++;
+                    if (answer.MemberAnswer.HasValue)
+                    {
+                        sheet.Range[rowNumber, columnNumber].DateTime = answer.MemberAnswer.Value;
+                        sheet.Range[rowNumber, columnNumber].CellStyle.Color = Color.DarkSeaGreen;
+                    }
+                    sheet.Range[rowNumber, columnNumber].BorderAround();
+                }
+                rowNumber = titleRow;
+                sheet.AutofitColumn(columnNumber);
+            }
+
+//            sheet.Range[1, 1, rowNumber, columnNumber].AutofitColumns();
+
+        }
+        private void GenerateOASWorksheetBodyOriginal(IWorksheet sheet, IList<IGrouping<string, OASWorksheetAnswers>> groupedAnswers, ref int rowNumber, ref int columnNumber)
+        {
+            var pdrText = "";
+            int pdrStartCol = 99;
+            foreach (var plan in groupedAnswers.FirstOrDefault().OrderBy(ga => ga.InputTitleSortIndex).ThenBy(ga => ga.InputSortIndex).ToList())
+            {
+                // Plan Do Review
+                columnNumber++;
+                if (pdrText != plan.InputTitle)
+                {
+                    pdrText = plan.InputTitle;
+                    sheet.Range[rowNumber, columnNumber].Text = plan.InputTitle;
+                    sheet.Range[rowNumber, columnNumber].CellStyle.Color = GetInputTitleColour(plan.InputTitle);
+                    sheet.Range[rowNumber, columnNumber].BorderAround();
+                    sheet.Range[rowNumber, columnNumber].CellStyle.Font.Bold = true;
+                    sheet.Range[rowNumber, columnNumber].CellStyle.HorizontalAlignment = ExcelHAlign.HAlignCenter;
+                    if (pdrStartCol > columnNumber)
+                        pdrStartCol = columnNumber;
+                    else
+                    {
+                        sheet.Range[rowNumber, pdrStartCol, rowNumber, columnNumber - 1].Merge();
+                        sheet.Range[rowNumber, pdrStartCol, rowNumber, columnNumber - 1].BorderAround();
+                        pdrStartCol = columnNumber;
+                    }
+                }
+
+                // iStatement
+                sheet.Range[rowNumber + 1, columnNumber].Text = plan.InputLabel;
+                sheet.Range[rowNumber + 1, columnNumber].BorderAround();
+                sheet.Range[rowNumber + 1, columnNumber].CellStyle.Font.Bold = true;
+                sheet.Range[rowNumber + 1, columnNumber].CellStyle.HorizontalAlignment = ExcelHAlign.HAlignCenter;
+                sheet.Range[rowNumber + 1, columnNumber].CellStyle.Rotation = 90;
+                sheet.Range[rowNumber + 1, columnNumber].CellStyle.WrapText = true;
+                sheet.SetRowHeight(rowNumber + 1, 200);
+                sheet.SetColumnWidth(columnNumber, 10);
+            }
+
+            // Member Name and answers
+            rowNumber++;
+            rowNumber++;
+            columnNumber = 0;
+            foreach (var groupedAnswer in groupedAnswers.OrderBy(ga => ga.Key))
+            {
+                columnNumber++;
+                sheet.Range[rowNumber, columnNumber].Text = groupedAnswer.Key;
+                sheet.Range[rowNumber, columnNumber].BorderAround();
+                sheet.Range[rowNumber, columnNumber].CellStyle.Font.Bold = true;
+
+                foreach (var answer in groupedAnswer.OrderBy(ga => ga.InputTitleSortIndex).ThenBy(ga => ga.InputSortIndex))
+                {
+                    columnNumber++;
+                    if (answer.MemberAnswer.HasValue)
+                    {
+                        sheet.Range[rowNumber, columnNumber].DateTime = answer.MemberAnswer.Value;
+                        sheet.Range[rowNumber, columnNumber].CellStyle.Color = Color.DarkSeaGreen;
+                    }
+                    sheet.Range[rowNumber, columnNumber].BorderAround();
+                }
+                rowNumber++;
+                columnNumber = 0;
+            }
+
+            sheet.Range[1, 1, rowNumber, 1].AutofitColumns();
+        }
+
+        public IWorkbook GenerateOASWorksheetWorkbook(List<OASWorksheetAnswers> worksheetAnswers, string groupName, string section, string unitName, bool forPdfOutput, bool formatLikeTerrain, bool breakByPatrol = false)
         {
             var worksheetAnswersGroupedByTemplate = worksheetAnswers.GroupBy(wa => wa.TemplateTitle + (breakByPatrol ? " - " + wa.MemberPatrol : ""));
             var workbook = CreateWorkbookWithSheets(worksheetAnswersGroupedByTemplate.Count());
@@ -1049,68 +1181,12 @@ namespace Topo.Services
                 sheet.SetRowHeight(rowNumber, 25);
 
                 rowNumber++;
-                var pdrText = "";
-                int pdrStartCol = 99;
-                var groupedAnswers = templatAnswerGroup.GroupBy(x => x.MemberName).ToList();
-                foreach (var plan in groupedAnswers.FirstOrDefault().OrderBy(ga => ga.InputTitleSortIndex).ThenBy(ga => ga.InputSortIndex).ToList())
-                {
-                    // Plan Do Review
-                    columnNumber++;
-                    if (pdrText != plan.InputTitle)
-                    {
-                        pdrText = plan.InputTitle;
-                        sheet.Range[rowNumber, columnNumber].Text = plan.InputTitle;
-                        sheet.Range[rowNumber, columnNumber].CellStyle.Color = GetInputTitleColour(plan.InputTitle);
-                        sheet.Range[rowNumber, columnNumber].BorderAround();
-                        sheet.Range[rowNumber, columnNumber].CellStyle.Font.Bold = true;
-                        sheet.Range[rowNumber, columnNumber].CellStyle.HorizontalAlignment = ExcelHAlign.HAlignCenter;
-                        if (pdrStartCol > columnNumber)
-                            pdrStartCol = columnNumber;
-                        else
-                        {
-                            sheet.Range[rowNumber, pdrStartCol, rowNumber, columnNumber - 1].Merge();
-                            sheet.Range[rowNumber, pdrStartCol, rowNumber, columnNumber - 1].BorderAround();
-                            pdrStartCol = columnNumber;
-                        }
-                    }
+                IList<IGrouping<string, OASWorksheetAnswers>> groupedAnswers = templatAnswerGroup.GroupBy(x => x.MemberName).ToList();
 
-                    // iStatement
-                    sheet.Range[rowNumber + 1, columnNumber].Text = plan.InputLabel;
-                    sheet.Range[rowNumber + 1, columnNumber].BorderAround();
-                    sheet.Range[rowNumber + 1, columnNumber].CellStyle.Font.Bold = true;
-                    sheet.Range[rowNumber + 1, columnNumber].CellStyle.HorizontalAlignment = ExcelHAlign.HAlignCenter;
-                    sheet.Range[rowNumber + 1, columnNumber].CellStyle.Rotation = 90;
-                    sheet.Range[rowNumber + 1, columnNumber].CellStyle.WrapText = true;
-                    sheet.SetRowHeight(rowNumber + 1, 200);
-                    sheet.SetColumnWidth(columnNumber, 10);
-                }
-
-                // Member Name and answers
-                rowNumber++;
-                rowNumber++;
-                columnNumber = 0;
-                foreach (var groupedAnswer in groupedAnswers.OrderBy(ga => ga.Key))
-                {
-                    columnNumber++;
-                    sheet.Range[rowNumber, columnNumber].Text = groupedAnswer.Key;
-                    sheet.Range[rowNumber, columnNumber].BorderAround();
-                    sheet.Range[rowNumber, columnNumber].CellStyle.Font.Bold = true;
-
-                    foreach (var answer in groupedAnswer.OrderBy(ga => ga.InputTitleSortIndex).ThenBy(ga => ga.InputSortIndex))
-                    {
-                        columnNumber++;
-                        if (answer.MemberAnswer.HasValue)
-                        {
-                            sheet.Range[rowNumber, columnNumber].DateTime = answer.MemberAnswer.Value;
-                            sheet.Range[rowNumber, columnNumber].CellStyle.Color = Color.DarkSeaGreen;
-                        }
-                        sheet.Range[rowNumber, columnNumber].BorderAround();
-                    }
-                    rowNumber++;
-                    columnNumber = 0;
-                }
-
-                sheet.Range[1, 1, rowNumber, 1].AutofitColumns();
+                if (formatLikeTerrain)
+                    GenerateOASWorksheetBodyLikeTerrain(sheet, groupedAnswers, ref rowNumber, ref columnNumber);
+                else
+                    GenerateOASWorksheetBodyOriginal(sheet, groupedAnswers, ref rowNumber, ref columnNumber);
 
                 sheet.PageSetup.PaperSize = ExcelPaperSize.PaperA3;
                 sheet.PageSetup.Orientation = ExcelPageOrientation.Landscape;
@@ -1127,6 +1203,7 @@ namespace Topo.Services
 
             return workbook;
         }
+
 
         public IWorkbook GenerateSIAWorkbook(List<SIAProjectListModel> siaProjects, string groupName, string section, string unitName, bool forPdfOutput)
         {

--- a/Topo/Controllers/OASController.cs
+++ b/Topo/Controllers/OASController.cs
@@ -78,11 +78,11 @@ namespace Topo.Controllers
                 model.SelectedStages = oasIndexViewModel.SelectedStages;
                 if (button == "OASReportPdf")
                 {
-                    return await OASWorkbook(oasIndexViewModel.SelectedUnitId, oasIndexViewModel.SelectedStages, oasIndexViewModel.HideCompletedMembers, Constants.OutputType.pdf, oasIndexViewModel.BreakByPatrol);
+                    return await OASWorkbook(oasIndexViewModel.SelectedUnitId, oasIndexViewModel.SelectedStages, oasIndexViewModel.HideCompletedMembers, Constants.OutputType.pdf, oasIndexViewModel.BreakByPatrol, oasIndexViewModel.FormatLikeTerrain);
                 }
                 if (button == "OASReportXlsx")
                 {
-                    return await OASWorkbook(oasIndexViewModel.SelectedUnitId, oasIndexViewModel.SelectedStages, oasIndexViewModel.HideCompletedMembers, Constants.OutputType.xlsx, oasIndexViewModel.BreakByPatrol);
+                    return await OASWorkbook(oasIndexViewModel.SelectedUnitId, oasIndexViewModel.SelectedStages, oasIndexViewModel.HideCompletedMembers, Constants.OutputType.xlsx, oasIndexViewModel.BreakByPatrol, oasIndexViewModel.FormatLikeTerrain);
                 }
             }
             else
@@ -93,7 +93,7 @@ namespace Topo.Controllers
             return View(model);
         }
 
-        private async Task<ActionResult> OASWorkbook(string selectedUnitId, string[] selectedStageTemplates, bool hideCompletedMembers, Constants.OutputType outputType, bool breakByPatrol)
+        private async Task<ActionResult> OASWorkbook(string selectedUnitId, string[] selectedStageTemplates, bool hideCompletedMembers, Constants.OutputType outputType, bool breakByPatrol, bool formatLikeTerrain)
         {
             var sortedAnswers = new List<OASWorksheetAnswers>();
             foreach (var selectedStageTemplate in selectedStageTemplates)
@@ -107,7 +107,7 @@ namespace Topo.Controllers
             var unitName = _storageService.SelectedUnitName ?? "";
             var section = _storageService.SelectedSection;
 
-            var workbook = _reportService.GenerateOASWorksheetWorkbook(sortedAnswers, groupName, section, unitName, outputType == Constants.OutputType.pdf, breakByPatrol);
+            var workbook = _reportService.GenerateOASWorksheetWorkbook(sortedAnswers, groupName, section, unitName, outputType == Constants.OutputType.pdf, formatLikeTerrain, breakByPatrol);
 
             //Stream 
             MemoryStream strm = new MemoryStream();

--- a/Topo/Views/OAS/Index.cshtml
+++ b/Topo/Views/OAS/Index.cshtml
@@ -20,13 +20,7 @@
             <span asp-validation-for="SelectedStages" class="text-danger"></span>
         </div>
     </div>
-    <div class="mt-3 mb-3 row">
-        <div class="col-sm-2">
-            <button type="submit" name="button" value="OASReportPdf" class="btn btn-primary">OAS Worksheet (pdf)</button> &nbsp;
-        </div>
-        <div class="col-sm-2">
-            <button type="submit" name="button" value="OASReportXlsx" class="btn btn-success">OAS Worksheet (xlsx)</button> &nbsp;
-        </div>
+     <div class="mt-3 mb-3 row">
         <div class="col-sm-3">
             @Html.DisplayNameFor(model => model.HideCompletedMembers) &nbsp;
             @Html.CheckBoxFor(model => model.HideCompletedMembers, new { id = "hideCompletedMembersCheckBoxId" })
@@ -35,8 +29,19 @@
             @Html.DisplayNameFor(model => model.BreakByPatrol) &nbsp;
             @Html.CheckBoxFor(model => model.BreakByPatrol, new { id = "breakByPatrolCheckBoxId" })
         </div>
+        <div class="col-sm-3">
+            @Html.DisplayNameFor(model => model.FormatLikeTerrain) &nbsp;
+            @Html.CheckBoxFor(model => model.FormatLikeTerrain, new { id = "formatLikeTerrainCheckBoxId" })
+        </div>
     </div>
-
+    <div class="mt-3 mb-3 row">
+        <div class="col-sm-2">
+            <button type="submit" name="button" value="OASReportPdf" class="btn btn-primary">OAS Worksheet (pdf)</button> &nbsp;
+        </div>
+        <div class="col-sm-2">
+            <button type="submit" name="button" value="OASReportXlsx" class="btn btn-success">OAS Worksheet (xlsx)</button> &nbsp;
+        </div>
+    </div>
 </form>
 
 @section Scripts {


### PR DESCRIPTION
I've modified OAS to add an option to export the report in the same format as Terrain, i.e. I-statements per row. Scouts per column. This will make it easier to transfer the statements back into Terrain after having printed them out for say a camp